### PR TITLE
12 threshold window example

### DIFF
--- a/coordinator.yml
+++ b/coordinator.yml
@@ -21,42 +21,35 @@ logicalSources:
         - logicalSourceName: "wind_turbines"
           fields:
                   - name: type
-                    type: CHAR
-                    length: 50
+                    type: TEXT
                   - name: metadata_generated
                     type: UINT64
                   - name: metadata_title
-                    type: CHAR
-                    length: 50
+                    type: TEXT
                   - name: metadata_id
-                    type: CHAR
-                    length: 50
+                    type: TEXT
                   - name: features_type
-                    type: CHAR
-                    length: 50
+                    type: TEXT
                   - name: features_properties_capacity
-                    type: UINT64
+                    type: INT64
                   - name: features_properties_efficiency
                     type: FLOAT32
                   - name: features_properties_mag
-                    type: FLOAT32
+                    type: INT64
                   - name: features_properties_time
                     type: UINT64
                   - name: features_properties_updated
                     type: UINT64
                   - name: features_properties_type
-                    type: CHAR
-                    length: 50
+                    type: TEXT
                   - name: features_geometry_type
-                    type: CHAR
-                    length: 50
+                    type: TEXT
                   - name: features_geometry_coordinates_longitude
                     type: FLOAT32
                   - name: features_geometry_coordinates_latitude
                     type: FLOAT32
                   - name: features_eventId
-                    type: CHAR
-                    length: 50
+                    type: TEXT
 
         - logicalSourceName: "iris"
           fields:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     networks:
       nebulastream-network:
         ipv4_address: 172.31.0.2
-  worker:
+  worker-1:
     image: nebulastream/nes-executable-image:latest
     entrypoint: ["bash", "-c", "sleep 3 && nesWorker --configPath=/tutorial/worker-1.yml"]
     volumes:
@@ -18,6 +18,14 @@ services:
     networks:
       nebulastream-network:
         ipv4_address: 172.31.0.3
+  worker-2:
+    image: nebulastream/nes-executable-image:latest
+    entrypoint: ["bash", "-c", "sleep 3 && nesWorker --configPath=/tutorial/worker-2.yml"]
+    volumes:
+      - ./:/tutorial
+    networks:
+      nebulastream-network:
+        ipv4_address: 172.31.0.4
   mosquitto:
     image: eclipse-mosquitto
     ports:

--- a/java-client-example/src/main/java/InferModelExample.java
+++ b/java-client-example/src/main/java/InferModelExample.java
@@ -17,9 +17,6 @@ import static stream.nebula.operators.window.TimeMeasure.minutes;
 
 /**
  * Example demonstrating the {@code inferModel} operation.
- * It then maps the attributes {@code f1}, {@code f2}, {@code f3}, and {@code f4} as inputs for the TensorFlow model.
- * The model computes three output fields which are stored as the attributes {@code iris0}, {@code iris1}, and {@code
- * iris2} in the output tuple.
  */
 public class InferModelExample {
 

--- a/java-client-example/src/main/java/ThresholdWindowExample.java
+++ b/java-client-example/src/main/java/ThresholdWindowExample.java
@@ -1,0 +1,71 @@
+import stream.nebula.exceptions.RESTException;
+import stream.nebula.operators.Aggregation;
+import stream.nebula.operators.sinks.FileSink;
+import stream.nebula.operators.sinks.Sink;
+import stream.nebula.operators.window.ThresholdWindow;
+import stream.nebula.runtime.NebulaStreamRuntime;
+import stream.nebula.runtime.Query;
+import stream.nebula.serialization.cpp.CppQueryRequestSerializer;
+
+import java.io.IOException;
+
+import static stream.nebula.expression.Expressions.attribute;
+
+/**
+ * Example demonstrating the threshold window operator.
+ */
+public class ThresholdWindowExample {
+
+    public static void main(String[] args) throws RESTException, IOException {
+        // Create a NebulaStream runtime and connect it to the NebulaStream coordinator.
+        NebulaStreamRuntime nebulaStreamRuntime = NebulaStreamRuntime.getRuntime();
+        nebulaStreamRuntime.getConfig().setHost("localhost").setPort("8081");
+
+        // Create a query reads from the wind turbines source.
+        Query query = nebulaStreamRuntime.readFromSource("wind_turbines");
+
+        // Create a streaming query with a threshold window
+        query
+                // TODO https://github.com/nebulastream/nebulastream/issues/3596
+                // At the moment, the attributes used in the threshold window operation have to be fully
+                // qualified with the source name, i.e., "wind_turbines$" in this case.
+                // TODO https://github.com/nebulastream/nebulastream/issues/3607
+                // The attribute that is used in the predicate, e.g., features_properties_mag, must be an integer.
+                .window(ThresholdWindow.of(attribute("wind_turbines$features_properties_mag").greaterThan(1000000)))
+                // TODO https://github.com/nebulastream/nebulastream/issues/3608
+                // The threshold window operator computes aggregates for each group but does not output the group field.
+                .byKey("wind_turbines$features_properties_time")
+                .apply(
+                        // TODO https://github.com/nebulastream/nebulastream/issues/3595
+                        // It is necessary to specify the name of the aggregated field. Also, right now the name must
+                        // be the aggregation function, e.g., "Count" for count aggregation and "Avg" for average
+                        // aggregation.
+                        Aggregation.count().as("wind_turbines$Count"),
+                        Aggregation.sum("wind_turbines$features_properties_capacity").as("wind_turbines$Sum"),
+                        Aggregation.min("wind_turbines$features_properties_capacity").as("wind_turbines$Min"),
+                        Aggregation.max("wind_turbines$features_properties_capacity").as("wind_turbines$Max"),
+                        // TODO https://github.com/nebulastream/nebulastream/issues/3602
+                        // The output of average aggregation is an integer and not a float.
+                        Aggregation.average("wind_turbines$features_properties_capacity").as("wind_turbines$Avg"));
+
+
+        // Write the output of the query to a CSV file.
+        query.sink(new FileSink("/tutorial/output/threshold-window-results.csv", "CSV_FORMAT",true));
+
+        // Submit the query to the coordinator.
+        // TODO https://github.com/nebulastream/nebulastream-java-client/issues/206
+        // The new Protobuf serializer does not serialize all the required information for the threshold operator and
+        // for count aggregation.
+        nebulaStreamRuntime.setSerializer(new CppQueryRequestSerializer());
+        nebulaStreamRuntime.executeQuery(query, "BottomUp");
+
+        // Once the query has finished, the file `/output/threshold-window-results.csv` contains 340 output tuples
+        // (341 lines). The first 4 lines are:
+        //wind_turbines$Count:INTEGER,wind_turbines$Sum:INTEGER,wind_turbines$Min:INTEGER,wind_turbines$Max:INTEGER,wind_turbines$Avg:INTEGER
+        //3,8556,2852,2852,2852
+        //6,17112,2852,2852,2852
+        //2,5704,2852,2852,2852
+        // These 3 tuples correspond to the first 25 tuples of the input file.
+    }
+
+}

--- a/worker-1.yml
+++ b/worker-1.yml
@@ -31,3 +31,6 @@ physicalSources:
             numberOfBuffersToProduce: 10
             numberOfTuplesToProducePerBuffer: 0
             skipHeader: false
+
+queryCompiler:
+  queryCompilerType: "NAUTILUS_QUERY_COMPILER"

--- a/worker-1.yml
+++ b/worker-1.yml
@@ -23,14 +23,6 @@ physicalSources:
                   numberOfBuffersToProduce: 1024
                   numberOfTuplesToProducePerBuffer: 0
                   skipHeader: true
-        - logicalSourceName: "iris"
-          physicalSourceName: "iris_1"
-          type: "CSVSource"
-          configuration:
-            filePath: /tutorial/resources/iris_short.csv
-            numberOfBuffersToProduce: 10
-            numberOfTuplesToProducePerBuffer: 0
-            skipHeader: false
 
 queryCompiler:
   queryCompilerType: "NAUTILUS_QUERY_COMPILER"

--- a/worker-2.yml
+++ b/worker-2.yml
@@ -1,0 +1,25 @@
+###
+### General configuration
+###
+logLevel: LOG_ERROR
+#logLevel: LOG_WARNING
+#logLevel: LOG_DEBUG
+
+###
+### Network configuration
+###
+localWorkerIp: 172.31.0.4
+coordinatorIp: coordinator
+
+###
+### Physical source configuration
+###
+physicalSources:
+        - logicalSourceName: "iris"
+          physicalSourceName: "iris_1"
+          type: "CSVSource"
+          configuration:
+            filePath: /tutorial/resources/iris_short.csv
+            numberOfBuffersToProduce: 10
+            numberOfTuplesToProducePerBuffer: 0
+            skipHeader: false


### PR DESCRIPTION
This PR creates adds an example for the threshold window operator.

A number of features are still not supported. These are documented in the file `ThresholdWindowExample`.

The threshold window relies on the new Nautilus query compiler. However, the `inferModel` example requires the old query compiler. Therefore, I have split the worker into two workers, which have different query compilers configured.

Closes #12.