### PR TITLE
25 fix tutorial

### DIFF
--- a/coordinator.yml
+++ b/coordinator.yml
@@ -30,19 +30,15 @@ logicalSources:
         - logicalSourceName: "wind_turbines"
           fields:
                   - name: type
-                    type: CHAR
-                    length: 50
+                    type: TEXT
                   - name: metadata_generated
                     type: UINT64
                   - name: metadata_title
-                    type: CHAR
-                    length: 50
+                    type: TEXT
                   - name: metadata_id
-                    type: CHAR
-                    length: 50
+                    type: TEXT
                   - name: features_type
-                    type: CHAR
-                    length: 50
+                    type: TEXT
                   - name: features_properties_capacity
                     type: UINT64
                   - name: features_properties_efficiency
@@ -54,18 +50,15 @@ logicalSources:
                   - name: features_properties_updated
                     type: UINT64
                   - name: features_properties_type
-                    type: CHAR
-                    length: 50
+                    type: TEXT
                   - name: features_geometry_type
-                    type: CHAR
-                    length: 50
+                    type: TEXT
                   - name: features_geometry_coordinates_longitude
                     type: FLOAT32
                   - name: features_geometry_coordinates_latitude
                     type: FLOAT32
                   - name: features_eventId
-                    type: CHAR
-                    length: 50
+                    type: TEXT
 
         - logicalSourceName: "iris"
           fields:

--- a/java-client-example/build.gradle
+++ b/java-client-example/build.gradle
@@ -14,4 +14,4 @@ dependencies {
 }
 
 apply plugin:'application'
-mainClassName = 'NebulaStreamTutorial'
+mainClassName = 'stream.nebula.example.NebulaStreamTutorial'

--- a/java-client-example/src/main/java/stream/nebula/example/NebulaStreamTutorial.java
+++ b/java-client-example/src/main/java/stream/nebula/example/NebulaStreamTutorial.java
@@ -29,11 +29,7 @@ public class NebulaStreamTutorial {
                 .apply(Aggregation.sum("features_properties_mag"));
 
         // Finish the query with a sink
-        Sink sink = query.sink(new FileSink("/tutorial/java-query-results.csv", "CSV_FORMAT", true));
-
-        // The line below is necessary because of a bug when submitting queries with aggregations over Protobuf.
-        // TODO https://github.com/nebulastream/nebulastream/issues/3429
-        nebulaStreamRuntime.setSerializer(new CppQueryRequestSerializer());
+        Sink sink = query.sink(new FileSink("/tutorial/java-query-results.csv", "CSV_FORMAT", false));
 
         // Submit the query to the coordinator.
         int queryId = nebulaStreamRuntime.executeQuery(query, "BottomUp");

--- a/java-client-example/src/main/java/stream/nebula/example/NebulaStreamTutorial.java
+++ b/java-client-example/src/main/java/stream/nebula/example/NebulaStreamTutorial.java
@@ -25,7 +25,7 @@ public class NebulaStreamTutorial {
         Query query = nebulaStreamRuntime
                 .readFromSource("wind_turbines")
                 .window(TumblingWindow.of(eventTime("features_properties_updated"), minutes(10)))
-                .byKey("metadata_id")
+                .byKey("features_properties_capacity")
                 .apply(Aggregation.sum("features_properties_mag"));
 
         // Finish the query with a sink

--- a/rest-query-with-csv-sink.json
+++ b/rest-query-with-csv-sink.json
@@ -1,4 +1,4 @@
 {
-  "userQuery": "Query::from(\"wind_turbines\").window(TumblingWindow::of(EventTime(Attribute(\"features_properties_updated\")), Minutes(10))).byKey(Attribute(\"metadata_id\")).apply(Sum(Attribute(\"features_properties_mag\"))).sink(FileSinkDescriptor::create(\"/tutorial/rest-query-result.csv\", \"CSV_FORMAT\", \"APPEND\"));",
+  "userQuery": "Query::from(\"wind_turbines\").window(TumblingWindow::of(EventTime(Attribute(\"features_properties_updated\")), Minutes(10))).byKey(Attribute(\"features_properties_capacity\")).apply(Sum(Attribute(\"features_properties_mag\"))).sink(FileSinkDescriptor::create(\"/tutorial/rest-query-result.csv\", \"CSV_FORMAT\", \"APPEND\"));",
   "placement": "BottomUp"
 }

--- a/rest-query-with-mqtt-sink.json
+++ b/rest-query-with-mqtt-sink.json
@@ -1,4 +1,4 @@
 {
-  "userQuery": "Query::from(\"wind_turbines\").window(TumblingWindow::of(EventTime(Attribute(\"features_properties_updated\")), Minutes(10))).byKey(Attribute(\"metadata_id\")).apply(Sum(Attribute(\"features_properties_mag\"))).sink(MQTTSinkDescriptor::create(\"ws://172.31.0.11:9001\", \"/nesui\", \"rfRqLGZRChg8eS30PEeR\", 5, MQTTSinkDescriptor::milliseconds, 500, MQTTSinkDescriptor::atLeastOnce, false));",
+  "userQuery": "Query::from(\"wind_turbines\").window(TumblingWindow::of(EventTime(Attribute(\"features_properties_updated\")), Minutes(10))).byKey(Attribute(\"features_properties_capacity\")).apply(Sum(Attribute(\"features_properties_mag\"))).sink(MQTTSinkDescriptor::create(\"ws://172.31.0.11:9001\", \"/nesui\", \"rfRqLGZRChg8eS30PEeR\", 5, MQTTSinkDescriptor::TimeUnits::milliseconds, 500, MQTTSinkDescriptor::ServiceQualities::atLeastOnce, false));",
   "placement": "BottomUp"
 }


### PR DESCRIPTION
# Description

This PR brings the tutorial in a state that it runs again. Fixes #25.

# Changes

- Replace `CHAR` with `TEXT` in schema to support new query compiler
- Group over `UINT64` because grouping over `TEXT` does not work. See also: https://github.com/nebulastream/nebulastream/issues/4524
- Fix gradle setup

# Verification

Manual tests.