### PR TITLE
Fix configuration files

### DIFF
--- a/coordinator.yml
+++ b/coordinator.yml
@@ -4,8 +4,6 @@
 logLevel: LOG_ERROR
 #logLevel: LOG_WARNING
 #logLevel: LOG_DEBUG
-optimizer:
-        distributedWindowChildThreshold: 3
 
 ###
 ### Network configuration

--- a/worker-1.yml
+++ b/worker-1.yml
@@ -11,7 +11,7 @@ logLevel: LOG_ERROR
 ### Network configuration
 ###
 localWorkerIp: 172.31.0.3
-coordinatorIp: coordinator
+coordinatorIp: 172.31.0.2
 
 ###
 ### Physical source configuration
@@ -35,3 +35,5 @@ physicalSources:
           configuration:
             filePath: /tutorial/resources/iris_short.csv
             skipHeader: false
+
+workerId: 2


### PR DESCRIPTION
- Remove the `distributedWindowChildThreshold` option from the coordinator configuration
- Change `coordinator` option in the worker configuration to use IP address instead of hostname